### PR TITLE
remove redundant dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,1 @@
 module github.com/jondot/goweight
-
-require github.com/mattn/go-zglob v0.0.0-20180803001819-2ea3427bfa53

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,3 @@
 module github.com/jondot/goweight
 
-require (
-	github.com/dustin/go-humanize v0.0.0-20180713052910-9f541cc9db5d
-	github.com/mattn/go-zglob v0.0.0-20180803001819-2ea3427bfa53
-)
+require github.com/mattn/go-zglob v0.0.0-20180803001819-2ea3427bfa53

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,10 @@
 module github.com/jondot/goweight
 
 require (
-	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
-	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v0.0.0-20180713052910-9f541cc9db5d
 	github.com/mattn/go-zglob v0.0.0-20180803001819-2ea3427bfa53
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/spf13/pflag v1.0.2
 	github.com/stretchr/testify v1.2.2 // indirect
 	github.com/thoas/go-funk v0.0.0-20180716193722-1060394a7713
-	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,6 @@
 module github.com/jondot/goweight
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v0.0.0-20180713052910-9f541cc9db5d
 	github.com/mattn/go-zglob v0.0.0-20180803001819-2ea3427bfa53
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.2.2 // indirect
-	github.com/thoas/go-funk v0.0.0-20180716193722-1060394a7713
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/dustin/go-humanize v0.0.0-20180713052910-9f541cc9db5d h1:lDrio3iIdNb0Gw9CgH7cQF+iuB5mOOjdJ9ERNJCBgb4=
-github.com/dustin/go-humanize v0.0.0-20180713052910-9f541cc9db5d/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/mattn/go-zglob v0.0.0-20180803001819-2ea3427bfa53 h1:tGfIHhDghvEnneeRhODvGYOt305TPwingKt6p90F4MU=
 github.com/mattn/go-zglob v0.0.0-20180803001819-2ea3427bfa53/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,4 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v0.0.0-20180713052910-9f541cc9db5d h1:lDrio3iIdNb0Gw9CgH7cQF+iuB5mOOjdJ9ERNJCBgb4=
 github.com/dustin/go-humanize v0.0.0-20180713052910-9f541cc9db5d/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/mattn/go-zglob v0.0.0-20180803001819-2ea3427bfa53 h1:tGfIHhDghvEnneeRhODvGYOt305TPwingKt6p90F4MU=
 github.com/mattn/go-zglob v0.0.0-20180803001819-2ea3427bfa53/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/thoas/go-funk v0.0.0-20180716193722-1060394a7713 h1:knaxjm6QMbUMNvuaSnJZmw0gRX4V/79JVUQiziJGM84=
-github.com/thoas/go-funk v0.0.0-20180716193722-1060394a7713/go.mod h1:mlR+dHGb+4YgXkf13rkQTuzrneeHANxOm6+ZnEV9HsA=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/mattn/go-zglob v0.0.0-20180803001819-2ea3427bfa53 h1:tGfIHhDghvEnneeRhODvGYOt305TPwingKt6p90F4MU=
-github.com/mattn/go-zglob v0.0.0-20180803001819-2ea3427bfa53/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,3 @@
-github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
-github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
-github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
-github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v0.0.0-20180713052910-9f541cc9db5d h1:lDrio3iIdNb0Gw9CgH7cQF+iuB5mOOjdJ9ERNJCBgb4=
@@ -10,11 +6,7 @@ github.com/mattn/go-zglob v0.0.0-20180803001819-2ea3427bfa53 h1:tGfIHhDghvEnneeR
 github.com/mattn/go-zglob v0.0.0-20180803001819-2ea3427bfa53/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/spf13/pflag v1.0.2 h1:Fy0orTDgHdbnzHcsOgfCN4LtHf0ec3wwtiwJqwvf3Gc=
-github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/thoas/go-funk v0.0.0-20180716193722-1060394a7713 h1:knaxjm6QMbUMNvuaSnJZmw0gRX4V/79JVUQiziJGM84=
 github.com/thoas/go-funk v0.0.0-20180716193722-1060394a7713/go.mod h1:mlR+dHGb+4YgXkf13rkQTuzrneeHANxOm6+ZnEV9HsA=
-gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
-gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/main.go
+++ b/main.go
@@ -2,11 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 
 	"github.com/jondot/goweight/pkg"
-
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
 var (
@@ -16,14 +15,22 @@ var (
 )
 
 var (
-	jsonOutput = kingpin.Flag("json", "Output json").Short('j').Bool()
-	buildTags  = kingpin.Flag("tags", "Build tags").String()
-	packages   = kingpin.Arg("packages", "Packages to build").String()
+	jsonOutput      = flag.Bool("json", false, "Output json")
+	jsonOutputShort = flag.Bool("j", false, "Output json")
+
+	buildTags = flag.String("tags", "", "Build tags")
+	packages  = flag.String("packages", "", "Packages to build")
+
+	showVersion = flag.Bool("version", false, "Shows version")
 )
 
 func main() {
-	kingpin.Version(fmt.Sprintf("%s (%s)", version, commit))
-	kingpin.Parse()
+	flag.Parse()
+	if *showVersion {
+		fmt.Printf("%s (%s)\n", version, commit)
+		return
+	}
+
 	weight := pkg.NewGoWeight()
 	if *buildTags != "" {
 		weight.BuildCmd = append(weight.BuildCmd, "-tags", *buildTags)
@@ -35,7 +42,7 @@ func main() {
 	work := weight.BuildCurrent()
 	modules := weight.Process(work)
 
-	if *jsonOutput {
+	if *jsonOutput || *jsonOutputShort {
 		m, _ := json.Marshal(modules)
 		fmt.Print(string(m))
 	} else {

--- a/pkg/goweight.go
+++ b/pkg/goweight.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/dustin/go-humanize"
+	"github.com/jondot/goweight/pkg/humanize"
 	"github.com/mattn/go-zglob"
 )
 

--- a/pkg/goweight.go
+++ b/pkg/goweight.go
@@ -5,12 +5,12 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/jondot/goweight/pkg/humanize"
-	"github.com/mattn/go-zglob"
 )
 
 var moduleRegex = regexp.MustCompile("packagefile (.*)=(.*)")
@@ -63,8 +63,18 @@ func (g *GoWeight) BuildCurrent() string {
 }
 
 func (g *GoWeight) Process(work string) []*ModuleEntry {
+	var files []string
 
-	files, err := zglob.Glob(work + "**/importcfg")
+	err := filepath.Walk(work, func(path string, _ os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if filepath.Base(path) == "importcfg" {
+			files = append(files, path)
+		}
+		return nil
+	})
+
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/goweight.go
+++ b/pkg/goweight.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/mattn/go-zglob"
-	"github.com/thoas/go-funk"
 )
 
 var moduleRegex = regexp.MustCompile("packagefile (.*)=(.*)")
@@ -70,15 +69,56 @@ func (g *GoWeight) Process(work string) []*ModuleEntry {
 		log.Fatal(err)
 	}
 
-	allLines := funk.Uniq(funk.FlattenDeep(funk.Map(files, func(file string) []string {
-		f, err := ioutil.ReadFile(file)
-		if err != nil {
-			return []string{}
+	allLines := uniqLines(flattenSLices(filesLines(files)))
+	var modules []*ModuleEntry
+	for _, line := range allLines {
+		module := processModule(line)
+		if module == nil {
+			continue
 		}
-		return strings.Split(string(f), "\n")
-	})))
-	modules := funk.Compact(funk.Map(allLines, processModule)).([]*ModuleEntry)
+		modules = append(modules, module)
+	}
 	sort.Slice(modules, func(i, j int) bool { return modules[i].Size > modules[j].Size })
 
 	return modules
+}
+
+func uniqLines(lines []string) []string {
+	m := make(map[string]struct{})
+
+	var uniqLines []string
+
+	for _, line := range lines {
+		_, seen := m[line]
+		if !seen {
+			uniqLines = append(uniqLines, line)
+			m[line] = struct{}{}
+		}
+	}
+
+	return uniqLines
+}
+
+func flattenSLices(slice [][]string) []string {
+	var flatten []string
+	for _, s := range slice {
+		flatten = append(flatten, s...)
+	}
+	return flatten
+}
+
+func filesLines(files []string) [][]string {
+	var lines [][]string
+	for _, f := range files {
+		lines = append(lines, fileLines(f))
+	}
+	return lines
+}
+
+func fileLines(file string) []string {
+	f, err := ioutil.ReadFile(file)
+	if err != nil {
+		return []string{}
+	}
+	return strings.Split(string(f), "\n")
 }

--- a/pkg/humanize/humanize.go
+++ b/pkg/humanize/humanize.go
@@ -1,0 +1,35 @@
+package humanize
+
+import (
+	"fmt"
+	"math"
+)
+
+func logn(n, b float64) float64 {
+	return math.Log(n) / math.Log(b)
+}
+
+func humanateBytes(s uint64, base float64, sizes []string) string {
+	if s < 10 {
+		return fmt.Sprintf("%d B", s)
+	}
+	e := math.Floor(logn(float64(s), base))
+	suffix := sizes[int(e)]
+	val := math.Floor(float64(s)/math.Pow(base, e)*10+0.5) / 10
+	f := "%.0f %s"
+	if val < 10 {
+		f = "%.1f %s"
+	}
+
+	return fmt.Sprintf(f, val, suffix)
+}
+
+// Bytes produces a human readable representation of an SI size.
+//
+// See also: ParseBytes.
+//
+// Bytes(82854982) -> 83 MB
+func Bytes(s uint64) string {
+	sizes := []string{"B", "kB", "MB", "GB", "TB", "PB", "EB"}
+	return humanateBytes(s, 1000, sizes)
+}


### PR DESCRIPTION
I use this tool all the time. As well as a large number of gophers around the world. Therefore, I thought that reducing the number of dependencies would be a very useful step for the development of this project. That's why:
1. Faster installation, by reducing the number of network requests to get dependencies. On the cheapest VPS, the original goweight was installed in 31.402s, mine in 8.363s. This is almost **4x acceleration**
2. Barely noticeable acceleration of startup by reducing the size of the executable file. It's almost imperceptible in a single run, but small wins add up to big wins when the tool is run hundreds of times every day by thousands of people around the world.
3. Reproducibility of builds and user safety. Over time, projects are abandoned, APIs change, github may be unavailable, and sometimes developer accounts are hacked to embed malicious functionality into library code. When we are not dependent on third-party solutions, we can be more confident that the project can be compiled without fear of "infection" and / or problems with the inaccessibility of something.

Binary size reduction on amd64 linux: 5848 B -> 3028 B

P.S. I would like to further develop and support goweight, which has not seen a release since May 2019. Assigning me as a maintainer will greatly help me improve the quality of the project and add more features to it. thanks